### PR TITLE
Add StatsPAI to Python causal inference libraries

### DIFF
--- a/src/libraries.md
+++ b/src/libraries.md
@@ -99,6 +99,8 @@ The following is a list of causal inference libraries, ordered by language and p
 
 - [scikit-uplift](https://github.com/maks-sh/scikit-uplift) - Basic meta-learner and uplift tools
 
+- [StatsPAI](https://github.com/brycewang-stanford/StatsPAI) - Agent-native causal inference and applied econometrics toolkit with 280+ functions, unifying R/Stata econometrics ecosystems (fixest, did, rdrobust, gsynth, DoubleML) into one Python API
+
 
 
 ## <img width="24" src="img/icon/r.png"> R


### PR DESCRIPTION
## Summary

- Add [StatsPAI](https://github.com/brycewang-stanford/StatsPAI) to the Python section of the causal inference libraries list
- StatsPAI is an agent-native Python toolkit for causal inference and applied econometrics with 280+ functions, unifying R/Stata econometrics ecosystems (fixest, did, rdrobust, gsynth, DoubleML) into one consistent Python API
- Placed at the end of the Python section following the existing ordering by popularity (stars)

## Test plan

- [x] Verified the markdown formatting matches existing entries
- [x] Confirmed the GitHub link is valid